### PR TITLE
remove extra stanzas from recipe-library

### DIFF
--- a/workspaces/blog.yaml
+++ b/workspaces/blog.yaml
@@ -19,13 +19,3 @@ dev:
   - nixpkgs.phpPackages.composer
   repos:
   - https://github.com/WordPress/WordPress
-compute:
-  compute_name: default
-  os_family: UBUNTU_22_04
-  region: us-west-1
-  resources:
-    cpus: 4+
-    disk: 50
-network:
-  category: vm-public
-  network_name: default

--- a/workspaces/dzwebsite.yaml
+++ b/workspaces/dzwebsite.yaml
@@ -19,9 +19,6 @@ compute:
   resources:
     cpus: 4+
     disk: 50
-network:
-  category: vm-public
-  network_name: default
 env:
   - key: ""
     value: ""

--- a/workspaces/dzwebsite.yaml
+++ b/workspaces/dzwebsite.yaml
@@ -12,13 +12,6 @@ dev:
     - nixpkgs.nodejs_21
   repos:
     - https://github.com/devzero-inc/devzero-website
-compute:
-  compute_name: default
-  os_family: UBUNTU_22_04
-  region: us-west-1
-  resources:
-    cpus: 4+
-    disk: 50
 env:
   - key: ""
     value: ""

--- a/workspaces/llm.yaml
+++ b/workspaces/llm.yaml
@@ -10,13 +10,3 @@ dev:
   - nixpkgs.rustup
   repos:
   - https://github.com/rustformers/llm
-compute:
-  compute_name: default
-  os_family: UBUNTU_22_04
-  region: us-west-1
-  resources:
-    cpus: 4+
-    disk: 50
-network:
-  category: vm-public
-  network_name: default

--- a/workspaces/rails.yaml
+++ b/workspaces/rails.yaml
@@ -55,13 +55,3 @@ dev:
   - nixpkgs.rustc
   repos:
   - https://github.com/rails/rails
-compute:
-  compute_name: default
-  os_family: UBUNTU_22_04
-  region: us-west-1
-  resources:
-    cpus: 4+
-    disk: 50
-network:
-  category: vm-public
-  network_name: default

--- a/workspaces/services.yaml
+++ b/workspaces/services.yaml
@@ -24,13 +24,3 @@ dev:
     - nixpkgs.jq
   repos:
     - https://github.com/devzero-inc/services
-compute:
-  compute_name: default
-  os_family: UBUNTU_22_04
-  region: us-west-1
-  resources:
-    cpus: 4+
-    disk: 50
-network:
-  category: vm-public
-  network_name: default


### PR DESCRIPTION
These show up here when I am in a DevZero team and am newly onboarded, except they won't work because they're trying to do some VM setup (which appears to be broken ☹️ )

<img width="1427" alt="Screen Shot 2024-02-15 at 9 03 23 PM" src="https://github.com/devzero-inc/workspace-recipe-library/assets/3050939/02b14141-f727-4f3c-8674-9db0fd0eb9e2">

